### PR TITLE
Conversion du temps en numérique et condition pour la f-measure

### DIFF
--- a/scripts/assets/fun.r
+++ b/scripts/assets/fun.r
@@ -1,3 +1,5 @@
+library(lubridate)
+
 median_filter <- function(x, y, w = 7, endr = "keep") {
   xmed <- runmed(x, w, endrule = endr)
   ymed <- runmed(y, w, endrule = endr)
@@ -12,6 +14,33 @@ median_filter <- function(x, y, w = 7, endr = "keep") {
   return(distmed)
 }
 
+#' Compute fmeasure
 f_measure <- function(vp, fp, fn) {
   return((2 * vp) / (2 * vp + fp + fn))
+}
+
+#' Convert datetime TS to cumulative TS in seconds with t0 = 0
+to_num <- function(datetime) {
+  time <- lubridate::second(datetime)
+
+  diff <- list()
+  for (i in seq_along(time)) {
+    if (i == 1) {
+      diff[[i]] <- 0
+      next
+    }
+
+    d <- time[i] - time[i - 1]
+
+    # Handle 59s against 0s
+    if (d < 0) {
+      d <- 60 - time[i - 1]
+    }
+
+    diff[[i]] <- d
+  }
+
+  time <- cumsum(unlist(diff))
+
+  return(time - time[1])
 }

--- a/scripts/data_prep.r
+++ b/scripts/data_prep.r
@@ -95,4 +95,29 @@ sprintf(
   n_rem, round(pct_rem)
 )
 
-write.csv(df_clean, "data/out/traces_groupe1_clean.csv")
+# ==============================================================================
+# Clean time
+# ==============================================================================
+# NOTE: We floor millisecond to last second to remove unwanted data such as:
+# [1] "2024-03-06 09:36:07.999000+00:00" [2] "2024-03-06 09:36:07+00:00"
+# The GPS record at t0 a time superior to the one of t+1. So, we (1) floor to
+# last seconds then (2) we removes duplicates.
+
+df_clean$time <- floor_date(as_datetime(df_clean$time), unit = "second")
+
+# Remove duplicated based on time for each track
+d_rem <- df_clean %>%
+  group_by(id_trace) %>%
+  group_modify(~ {
+    .x %>%
+      distinct(.x$time, .keep_all = TRUE)
+  })
+
+sprintf(
+  "Removing %s duplicates data based on time (%.2f %% of the sample)",
+  nrow(df_clean) - nrow(d_rem),
+  ((nrow(df_clean) - nrow(d_rem)) / nrow(df_clean)) * 100
+)
+
+# write data
+write.csv(d_rem, "data/out/traces_groupe1_clean.csv")

--- a/scripts/sensibility_analysis.r
+++ b/scripts/sensibility_analysis.r
@@ -54,6 +54,7 @@ out <- foreach(
   # syntax ; it's the foreach loop)
   if (length(lon) <= 1) (return(0))
   lat <- df_clean[df_clean$id_trace == id, "lat"]
+  time <- to_num(as_datetime(df_clean[df_clean$id_trace == id, "time"]))
 
   # running st-dbscan
   res <- stdbscan(lon, lat, time, eps, eps2, minpts)

--- a/scripts/sensibility_analysis.r
+++ b/scripts/sensibility_analysis.r
@@ -46,14 +46,14 @@ out <- foreach(
   eps <- df_store[i, "eps"]
   eps2 <- df_store[i, "eps2"]
   minpts <- df_store[i, "minpts"]
+  id <- df_store[i, "id"]
 
   # Get the parameters of the track.
-  lon <- df_clean[df_clean$id_trace == df_store[i, "id"], "lon"]
+  lon <- df_clean[df_clean$id_trace == id, "lon"]
   # Check if the track is empty, if so, next track and return 0 (I know, weird
   # syntax ; it's the foreach loop)
   if (length(lon) <= 1) (return(0))
-  lat <- df_clean[df_clean$id_trace == df_store[i, "id"], "lat"]
-  time <- as_datetime(df_clean[df_clean$id_trace == df_store[i, "id"], "time"])
+  lat <- df_clean[df_clean$id_trace == id, "lat"]
 
   # running st-dbscan
   res <- stdbscan(lon, lat, time, eps, eps2, minpts)

--- a/scripts/sensibility_analysis.r
+++ b/scripts/sensibility_analysis.r
@@ -46,7 +46,12 @@ out <- foreach(
   eps <- df_store[i, "eps"]
   eps2 <- df_store[i, "eps2"]
   minpts <- df_store[i, "minpts"]
+
+  # Get the parameters of the track.
   lon <- df_clean[df_clean$id_trace == df_store[i, "id"], "lon"]
+  # Check if the track is empty, if so, next track and return 0 (I know, weird
+  # syntax ; it's the foreach loop)
+  if (length(lon) <= 1) (return(0))
   lat <- df_clean[df_clean$id_trace == df_store[i, "id"], "lat"]
   time <- as_datetime(df_clean[df_clean$id_trace == df_store[i, "id"], "time"])
 


### PR DESCRIPTION
## Condition

L'objectif de la condition est de prévenir une division par 0 lors du calcul de la f-measure. La condition est appliquée directement après que la première donnée ait été sélectionnée (515fc2d498100f45ae92134e94ef20c9768d9237)

## Datetime en num

1. La variable temporelle est convertie en seconde et les données dupliquées sont enlevées. Le but est de retirer des données du type t0 < t-1 ; ça paraît improbable, mais, ça existe bel et bien (5a37ec6ecde5d6794a740c5781ca15487e96543b).
2. Conversion proprement dite du temps (class datetime) en temps cumulé (class num, unité = s) avec 0 pour origine.
    1. Création d'une fonction (eabb1fb9cf09d34106807f51617ba26ed7b879c7)
    2. Implémentation de la fonction (6250c1217643b30890d3f7b2a42dc028c531a48e)